### PR TITLE
feat: add llms.txt + llms-full.txt + plain-MD export for AI agents

### DIFF
--- a/src/Builder/Builder.php
+++ b/src/Builder/Builder.php
@@ -45,6 +45,8 @@ final class Builder
 
     private bool $generateNoJekyll = true;
 
+    private bool $llmsExport = true;
+
     private ?string $readmeIndexPath = null;
 
     /** @var list<string> */
@@ -180,6 +182,13 @@ final class Builder
         return $this;
     }
 
+    public function llmsExport(bool $llmsExport = true): self
+    {
+        $this->llmsExport = $llmsExport;
+
+        return $this;
+    }
+
     public function readmeIndex(string $readmeIndexPath = 'README.md'): self
     {
         $this->readmeIndexPath = $readmeIndexPath;
@@ -225,6 +234,7 @@ final class Builder
                 editBranch: trim($this->editBranch) !== '' ? trim($this->editBranch) : 'main',
                 generateSitemap: $this->generateSitemap,
                 generateNoJekyll: $this->generateNoJekyll,
+                llmsExport: $this->llmsExport,
             ),
             baseUrl: $this->baseUrl,
             rightSidebar: $this->rightSidebar,

--- a/src/Config/SiteMetadata.php
+++ b/src/Config/SiteMetadata.php
@@ -17,6 +17,7 @@ final readonly class SiteMetadata
         public string $editBranch = 'main',
         public bool $generateSitemap = true,
         public bool $generateNoJekyll = true,
+        public bool $llmsExport = true,
     ) {
     }
 }

--- a/src/Render/SiteBuilder.php
+++ b/src/Render/SiteBuilder.php
@@ -79,6 +79,10 @@ final readonly class SiteBuilder
         if ($config->metadata->generateNoJekyll) {
             $this->writeNoJekyll($config);
         }
+
+        if ($config->metadata->llmsExport) {
+            $this->writeLlmExport($config, $documents, ! $hasRootIndex);
+        }
     }
 
     /** @param list<array{slug: string, label: string, default: bool}> $versions */
@@ -145,6 +149,10 @@ final readonly class SiteBuilder
 
         if ($config->metadata->generateNoJekyll) {
             $this->writeNoJekyll($config, $writeTarget);
+        }
+
+        if ($config->metadata->llmsExport) {
+            $this->writeLlmExport($config, $documents, ! $hasRootIndex);
         }
     }
 
@@ -842,5 +850,82 @@ HTML;
     </div>
 </div>
 HTML;
+    }
+
+    /** @param list<Document> $documents */
+    private function writeLlmExport(BuildConfig $config, array $documents, bool $includeGeneratedRoot): void
+    {
+        $outputPath = rtrim($config->outputPath, '/');
+
+        $siteUrl = rtrim($config->metadata->siteUrl, '/');
+
+        $entries = $documents;
+
+        if ($includeGeneratedRoot) {
+            array_unshift($entries, new Document(
+                sourcePath: '',
+                relativePath: '',
+                outputPath: 'index.html',
+                title: $config->metadata->title,
+                markdown: '# ' . $config->metadata->title . "\n\n" . $config->metadata->description,
+                description: $config->metadata->description,
+            ));
+        }
+
+        $llmsItems = array_map(
+            function (Document $doc) use ($siteUrl): string {
+                $url = $siteUrl !== '' ? $siteUrl . $doc->url() : $doc->url();
+                $desc = $doc->description !== '' ? $doc->description : $doc->title;
+                return '- ' . $url . ': ' . $desc;
+            },
+            $entries,
+        );
+
+        $llmsTitle = '# ' . $config->metadata->title;
+        $llmsDesc = '> ' . $config->metadata->description;
+
+        file_put_contents(
+            $outputPath . '/llms.txt',
+            $llmsTitle . "\n" . $llmsDesc . "\n\n## Docs\n\n" . implode("\n", $llmsItems) . "\n",
+        );
+
+        $fullParts = array_map(
+            function (Document $doc): string {
+                $text = '# ' . $doc->title . "\n\n";
+                if ($doc->description !== '') {
+                    $text .= $doc->description . "\n\n";
+                }
+
+                return $text . $this->plainText($doc->markdown !== '' ? $doc->markdown : ($doc->html));
+            },
+            $entries,
+        );
+
+        file_put_contents(
+            $outputPath . '/llms-full.txt',
+            implode("\n\n---\n\n", $fullParts) . "\n",
+        );
+
+        $exportDir = $outputPath . '/export';
+        if (! is_dir($exportDir)) {
+            mkdir($exportDir, 0777, true);
+        }
+
+        $mdParts = array_map(
+            function (Document $doc): string {
+                $md = '# ' . $doc->title . "\n\n";
+                if ($doc->description !== '') {
+                    $md .= '> ' . $doc->description . "\n\n";
+                }
+
+                return $md . $doc->markdown;
+            },
+            $entries,
+        );
+
+        file_put_contents(
+            $exportDir . '/docs.md',
+            implode("\n\n---\n\n", $mdParts) . "\n",
+        );
     }
 }

--- a/tests/Feature/BuildSiteTest.php
+++ b/tests/Feature/BuildSiteTest.php
@@ -504,3 +504,36 @@ it('renders a kb search overlay with keyboard shortcut hint', function (): void 
         ->toContain('data-docsmith-search-overlay-results')
         ->toContain('(⌘K)');
 });
+
+it('generates llms.txt, llms-full.txt, and export/docs.md for ai consumption', function (): void {
+    $sourcePath = __DIR__ . '/../Fixtures/Content';
+    $outputPath = sys_get_temp_dir() . '/docsmith-llm-export-' . uniqid();
+
+    Docsmith::make()
+        ->source($sourcePath)
+        ->output($outputPath)
+        ->title('Docsmith Docs')
+        ->description('Generated documentation for testing.')
+        ->siteUrl('https://example.com/docs')
+        ->build();
+
+    expect($outputPath . '/llms.txt')->toBeFile();
+    $llms = file_get_contents($outputPath . '/llms.txt');
+    expect($llms)
+        ->toContain('# Docsmith Docs')
+        ->toContain('https://example.com/docs/installation')
+        ->toContain('https://example.com/docs/guides/configuration')
+        ->toContain('## Docs');
+
+    expect($outputPath . '/llms-full.txt')->toBeFile();
+    $full = file_get_contents($outputPath . '/llms-full.txt');
+    expect($full)
+        ->toContain('# Installation')
+        ->toContain('# Configuration');
+
+    expect($outputPath . '/export/docs.md')->toBeFile();
+    $docsMd = file_get_contents($outputPath . '/export/docs.md');
+    expect($docsMd)
+        ->toContain('# Installation')
+        ->toContain('# Configuration');
+});


### PR DESCRIPTION
Generates AI-consumable documentation artifacts alongside the HTML site:

- llms.txt: directory listing per the llmstxt proposal with titles, descriptions, and URLs for all pages
- llms-full.txt: all page content concatenated as plain text separated by --- for easy AI ingestion
- export/docs.md: single merged Markdown file with all pages

- SiteMetadata: add llmsExport toggle (default true)
- Builder: add llmsExport() fluent method
- SiteBuilder: writeLlmExport() generates all three files
- Tests: verify export file contents and structure