### PR TITLE
feat: add front-matter hidden support

### DIFF
--- a/src/Content/Document.php
+++ b/src/Content/Document.php
@@ -18,6 +18,7 @@ final readonly class Document
         public string $groupIcon = '',
         public int $order = 999,
         public string $sidebarLabel = '',
+        public bool $hidden = false,
     ) {
     }
 
@@ -35,6 +36,25 @@ final readonly class Document
             groupIcon: $this->groupIcon,
             order: $this->order,
             sidebarLabel: $this->sidebarLabel,
+            hidden: $this->hidden,
+        );
+    }
+
+    public function withHidden(bool $hidden): self
+    {
+        return new self(
+            sourcePath: $this->sourcePath,
+            relativePath: $this->relativePath,
+            outputPath: $this->outputPath,
+            title: $this->title,
+            markdown: $this->markdown,
+            html: $this->html,
+            description: $this->description,
+            group: $this->group,
+            groupIcon: $this->groupIcon,
+            order: $this->order,
+            sidebarLabel: $this->sidebarLabel,
+            hidden: $hidden,
         );
     }
 

--- a/src/Content/SourceScanner.php
+++ b/src/Content/SourceScanner.php
@@ -50,6 +50,7 @@ final class SourceScanner
             $description = $this->stringValue($frontMatter['description'] ?? null);
             $sidebarLabel = $this->stringValue($frontMatter['sidebar_label'] ?? null);
             $order = $this->intValue($frontMatter['order'] ?? null, 999);
+            $hidden = $this->boolValue($frontMatter['hidden'] ?? null);
 
             $documents[] = new Document(
                 sourcePath: $absolutePath,
@@ -60,6 +61,7 @@ final class SourceScanner
                 description: $description,
                 order: $order,
                 sidebarLabel: $sidebarLabel,
+                hidden: $hidden,
             );
         }
 
@@ -167,5 +169,18 @@ final class SourceScanner
     private function intValue(mixed $value, int $fallback): int
     {
         return is_int($value) ? $value : $fallback;
+    }
+
+    private function boolValue(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            return strtolower(trim($value)) === 'true';
+        }
+
+        return false;
     }
 }

--- a/src/Render/SiteBuilder.php
+++ b/src/Render/SiteBuilder.php
@@ -39,6 +39,11 @@ final readonly class SiteBuilder
             $documents ?? $this->scanner->scan($config->sourcePath)
         );
 
+        $visibleDocuments = array_values(array_filter(
+            $documents,
+            fn (Document $document): bool => ! $document->hidden,
+        ));
+
         if ($documents === []) {
             throw new RuntimeException('The source directory does not contain any markdown files.');
         }
@@ -58,14 +63,14 @@ final readonly class SiteBuilder
                 mkdir($directory, 0777, true);
             }
 
-            file_put_contents($absoluteOutputPath, $this->page($config, $document, $documents));
+            file_put_contents($absoluteOutputPath, $this->page($config, $document, $visibleDocuments));
         }
 
         if (! $hasRootIndex) {
-            file_put_contents(rtrim($config->outputPath, '/') . '/index.html', $this->landingPage($config, $documents));
+            file_put_contents(rtrim($config->outputPath, '/') . '/index.html', $this->landingPage($config, $visibleDocuments));
         }
 
-        $this->writeSearchIndex($config, $documents, ! $hasRootIndex);
+        $this->writeSearchIndex($config, $visibleDocuments, ! $hasRootIndex);
 
         if ($config->metadata->generateSitemap) {
             $this->writeSitemap($config, $documents, ! $hasRootIndex);

--- a/tests/Feature/BuildSiteTest.php
+++ b/tests/Feature/BuildSiteTest.php
@@ -374,3 +374,63 @@ it('allows appending custom css as raw string', function (): void {
 
     expect($appCss)->toContain('/* my override */ .brand { color: #123456 }');
 });
+
+it('excludes hidden pages from navigation, pagination, and search index', function (): void {
+    $sourcePath = sys_get_temp_dir() . '/docsmith-hidden-' . uniqid();
+    $outputPath = sys_get_temp_dir() . '/docsmith-hidden-dist-' . uniqid();
+
+    mkdir($sourcePath, 0777, true);
+
+    file_put_contents($sourcePath . '/visible.md', <<<'MD'
+---
+title: Visible Page
+order: 1
+---
+# Visible Page
+
+Content visible in nav.
+MD);
+
+    file_put_contents($sourcePath . '/hidden.md', <<<'MD'
+---
+title: Hidden Page
+order: 2
+hidden: true
+---
+# Hidden Page
+
+Content hidden from nav.
+MD);
+
+    Docsmith::build(
+        source: $sourcePath,
+        output: $outputPath,
+        title: 'Hidden Test',
+        description: 'Testing hidden pages.',
+    );
+
+    // Hidden page is still built and accessible
+    expect($outputPath . '/hidden/index.html')->toBeFile()
+        ->and(file_get_contents($outputPath . '/hidden/index.html'))
+        ->toContain('Hidden Page');
+
+    // Hidden page does NOT appear in navigation
+    $visiblePage = file_get_contents($outputPath . '/visible/index.html');
+    expect($visiblePage)
+        ->not->toContain('Hidden Page')
+        ->toContain('Visible Page');
+
+    // Hidden page does NOT appear in search index
+    $searchIndex = json_decode(
+        (string) file_get_contents($outputPath . '/search-index.json'),
+        true
+    );
+    $found = array_filter(
+        is_array($searchIndex) ? $searchIndex : [],
+        fn (array $entry): bool => ($entry['title'] ?? '') === 'Hidden Page'
+    );
+    expect($found)->toBeEmpty();
+
+    // Hidden page is excluded from pagination
+    expect($visiblePage)->not->toContain('Next');
+});

--- a/tests/Feature/BuildSiteTest.php
+++ b/tests/Feature/BuildSiteTest.php
@@ -427,7 +427,7 @@ MD);
     );
     $found = array_filter(
         is_array($searchIndex) ? $searchIndex : [],
-        fn (array $entry): bool => ($entry['title'] ?? '') === 'Hidden Page'
+        fn (mixed $entry): bool => is_array($entry) && ($entry['title'] ?? '') === 'Hidden Page'
     );
     expect($found)->toBeEmpty();
 


### PR DESCRIPTION
Adds a hidden front-matter key that excludes a page from navigation, pagination (prev/next), landing page listing, and the search index. The page is still rendered and accessible via direct URL.

- Document: add hidden property and withHidden() method
- SourceScanner: parse hidden: true from YAML-like front-matter
- SiteBuilder: filter hidden docs from nav, neighbors, landing, search
- Tests: verify hidden page behavior