### PR TITLE
feat: add versioned documentation support with version switcher

### DIFF
--- a/src/Assets/AssetPublisher.php
+++ b/src/Assets/AssetPublisher.php
@@ -175,6 +175,41 @@ a {
     color: var(--accent);
 }
 
+.version-switcher {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-bottom: 0.75rem;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 0.65rem;
+    background: var(--panel);
+    font-size: 0.85rem;
+}
+
+.version-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.45rem;
+    text-decoration: none;
+    color: var(--muted);
+    font-size: 0.82rem;
+    transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.version-link:hover {
+    background: var(--accent-soft);
+    color: var(--accent);
+}
+
+.version-link-current {
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-weight: 700;
+}
+
 .search input {
     width: 100%;
     border: 1px solid var(--border);

--- a/src/Builder/Builder.php
+++ b/src/Builder/Builder.php
@@ -7,9 +7,13 @@ namespace Docsmith\Builder;
 use Docsmith\Compatibility\ReadmeIndexImporter;
 use Docsmith\Config\BuildConfig;
 use Docsmith\Config\SiteMetadata;
+use Docsmith\Config\VersionConfig;
 use Docsmith\Markdown\CommonMarkRenderer;
 use Docsmith\Render\SiteBuilder;
 use LogicException;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 
 final class Builder
 {
@@ -45,6 +49,35 @@ final class Builder
 
     /** @var list<string> */
     private array $readmeSkipSections = [];
+
+    /** @var list<VersionConfig> */
+    private array $versions = [];
+
+    /** @param array<string, array{label: string, source: string, default?: bool}> $versions */
+    public function versions(array $versions): self
+    {
+        $defaults = array_filter($versions, fn (array $v): bool => (bool) ($v['default'] ?? false));
+
+        if (count($defaults) > 1) {
+            throw new LogicException('Only one version can be marked as default.');
+        }
+
+        $this->versions = [];
+        foreach ($versions as $slug => $config) {
+            $this->versions[] = VersionConfig::fromArray((string) $slug, $config);
+        }
+
+        if ($this->versions !== [] && $defaults === []) {
+            $this->versions[0] = new VersionConfig(
+                slug: $this->versions[0]->slug,
+                label: $this->versions[0]->label,
+                sourcePath: $this->versions[0]->sourcePath,
+                isDefault: true,
+            );
+        }
+
+        return $this;
+    }
 
     public function source(string $sourcePath): self
     {
@@ -164,6 +197,11 @@ final class Builder
 
     public function build(): void
     {
+        if ($this->versions !== []) {
+            $this->buildVersions();
+            return;
+        }
+
         $documents = null;
         $sourcePath = $this->sourcePath;
 
@@ -193,6 +231,88 @@ final class Builder
         );
 
         (new SiteBuilder())->build($config, $documents);
+    }
+
+    private function buildVersions(): void
+    {
+        $outputPath = $this->requireOutputPath();
+
+        $versionsData = array_map(
+            fn (VersionConfig $v): array => ['slug' => $v->slug, 'label' => $v->label, 'default' => $v->isDefault],
+            $this->versions,
+        );
+
+        foreach ($this->versions as $version) {
+            $versionDocPath = rtrim($outputPath, '/') . '/' . $version->slug;
+            $isDefault = $version->isDefault;
+
+            $config = BuildConfig::fromInput(
+                sourcePath: $version->sourcePath,
+                outputPath: $versionDocPath,
+                metadata: new SiteMetadata(
+                    title: $this->title,
+                    description: $this->description,
+                    accentColor: $this->accentColor !== '' ? $this->accentColor : '#ff2d20',
+                    accentColorDark: $this->accentColorDark,
+                    customCss: $this->customCss,
+                    repositoryUrl: $this->normalizedRepositoryUrl(),
+                    siteUrl: $this->normalizedSiteUrl(),
+                    editBranch: trim($this->editBranch) !== '' ? trim($this->editBranch) : 'main',
+                    generateSitemap: $this->generateSitemap,
+                    generateNoJekyll: $this->generateNoJekyll,
+                ),
+                baseUrl: $this->baseUrl,
+                rightSidebar: $this->rightSidebar,
+            );
+
+            (new SiteBuilder())->buildVersion(
+                config: $config,
+                versions: $versionsData,
+                currentSlug: $version->slug,
+                isDefault: $isDefault,
+                rootOutput: $outputPath,
+            );
+        }
+
+        $this->writeAssetsToRoot($outputPath);
+    }
+
+    private function writeAssetsToRoot(string $outputPath): void
+    {
+        $assetsSource = rtrim($outputPath, '/') . '/' . $this->versions[0]->slug . '/assets';
+        $assetsTarget = rtrim($outputPath, '/') . '/assets';
+
+        if (is_dir($assetsSource) && ! is_dir($assetsTarget)) {
+            $this->copyDirectory($assetsSource, $assetsTarget);
+        }
+    }
+
+    private function copyDirectory(string $source, string $target): void
+    {
+        if (! is_dir($target)) {
+            mkdir($target, 0777, true);
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            if (! $item instanceof SplFileInfo) {
+                continue;
+            }
+
+            $dest = $target . '/' . $iterator->getSubPathname();
+
+            if ($item->isDir()) {
+                if (! is_dir($dest)) {
+                    mkdir($dest, 0777, true);
+                }
+            } else {
+                copy($item->getRealPath() ?: (string) $item, $dest);
+            }
+        }
     }
 
     private function requireSourcePath(): string

--- a/src/Config/VersionConfig.php
+++ b/src/Config/VersionConfig.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Docsmith\Config;
+
+use Docsmith\Exception\InvalidBuildConfiguration;
+
+final readonly class VersionConfig
+{
+    /** @param array{label: string, source: string, default?: bool} $config */
+    public static function fromArray(string $slug, array $config): self
+    {
+        $realPath = realpath($config['source']);
+
+        if ($realPath === false || ! is_dir($realPath)) {
+            throw new InvalidBuildConfiguration(
+                sprintf('Version [%s] source directory [%s] does not exist.', $slug, $config['source']),
+            );
+        }
+
+        return new self(
+            slug: $slug,
+            label: $config['label'],
+            sourcePath: str_replace('\\', '/', $realPath),
+            isDefault: (bool) ($config['default'] ?? false),
+        );
+    }
+
+    public function __construct(
+        public string $slug,
+        public string $label,
+        public string $sourcePath,
+        public bool $isDefault = false,
+    ) {
+    }
+}

--- a/src/Render/SiteBuilder.php
+++ b/src/Render/SiteBuilder.php
@@ -81,8 +81,83 @@ final readonly class SiteBuilder
         }
     }
 
+    /** @param list<array{slug: string, label: string, default: bool}> $versions */
+    public function buildVersion(
+        BuildConfig $config,
+        array $versions,
+        string $currentSlug,
+        bool $isDefault,
+        string $rootOutput,
+    ): void {
+        $documents = array_map(
+            fn (Document $document): Document => $document->html === ''
+                ? $document->withHtml($this->renderer->render($document->markdown))
+                : $document,
+            $this->scanner->scan($config->sourcePath)
+        );
+
+        if ($documents === []) {
+            throw new RuntimeException('The source directory does not contain any markdown files.');
+        }
+
+        if (! is_dir($config->outputPath)) {
+            mkdir($config->outputPath, 0777, true);
+        }
+
+        $this->assets->publish($config->outputPath, $config->metadata);
+        $hasRootIndex = $this->hasRootIndex($documents);
+
+        $versionSwitcher = $this->versionSwitcherHtml($versions, $currentSlug);
+
+        foreach ($documents as $document) {
+            $absoluteOutputPath = rtrim($config->outputPath, '/') . '/' . $document->outputPath;
+            $directory = dirname($absoluteOutputPath);
+
+            if (! is_dir($directory)) {
+                mkdir($directory, 0777, true);
+            }
+
+            file_put_contents(
+                $absoluteOutputPath,
+                $this->page($config, $document, $documents, $versionSwitcher),
+            );
+
+            if ($isDefault) {
+                $rootPath = rtrim($rootOutput, '/') . '/' . $document->outputPath;
+                $rootDir = dirname($rootPath);
+                if (! is_dir($rootDir)) {
+                    mkdir($rootDir, 0777, true);
+                }
+
+                file_put_contents(
+                    $rootPath,
+                    $this->page($config, $document, $documents, $versionSwitcher),
+                );
+            }
+        }
+
+        if (! $hasRootIndex) {
+            $landing = $this->landingPage($config, $documents, $versionSwitcher);
+            file_put_contents(rtrim($config->outputPath, '/') . '/index.html', $landing);
+
+            if ($isDefault) {
+                file_put_contents(rtrim($rootOutput, '/') . '/index.html', $landing);
+            }
+        }
+
+        $this->writeSearchIndex($config, $documents, ! $hasRootIndex);
+
+        if ($config->metadata->generateSitemap) {
+            $this->writeSitemap($config, $documents, ! $hasRootIndex);
+        }
+
+        if ($config->metadata->generateNoJekyll) {
+            $this->writeNoJekyll($config);
+        }
+    }
+
     /** @param list<Document> $documents */
-    private function page(BuildConfig $config, Document $document, array $documents): string
+    private function page(BuildConfig $config, Document $document, array $documents, string $versionSwitcher = ''): string
     {
         $tocData = $this->tocFromHtml($document->html);
         $toc = $tocData['items'];
@@ -122,6 +197,7 @@ final readonly class SiteBuilder
                 <button type="button" class="mobile-menu-toggle" data-docsmith-menu-toggle aria-expanded="false" aria-controls="docsmith-sidebar-panel" aria-label="Open menu"><span class="mobile-menu-icon" aria-hidden="true"></span><span class="sr-only">Toggle menu</span></button>
             </div>
             <div class="sidebar-panel" id="docsmith-sidebar-panel" data-docsmith-sidebar-panel>
+                {$versionSwitcher}
                 {$this->sidebarActions($config)}
                 <div class="search">
                     <input type="search" placeholder="Search pages" aria-label="Search pages" data-docsmith-search>
@@ -156,7 +232,7 @@ HTML;
     }
 
     /** @param list<Document> $documents */
-    private function landingPage(BuildConfig $config, array $documents): string
+    private function landingPage(BuildConfig $config, array $documents, string $versionSwitcher = ''): string
     {
         $pageLinks = array_map(
             fn (Document $document): string => sprintf(
@@ -195,6 +271,7 @@ HTML;
                 <button type="button" class="mobile-menu-toggle" data-docsmith-menu-toggle aria-expanded="false" aria-controls="docsmith-sidebar-panel" aria-label="Open menu"><span class="mobile-menu-icon" aria-hidden="true"></span><span class="sr-only">Toggle menu</span></button>
             </div>
             <div class="sidebar-panel" id="docsmith-sidebar-panel" data-docsmith-sidebar-panel>
+                {$versionSwitcher}
                 {$this->sidebarActions($config)}
                 <div class="search">
                     <input type="search" placeholder="Search pages" aria-label="Search pages" data-docsmith-search>
@@ -716,5 +793,31 @@ HTML;
         );
 
         return '<aside class="toc-sidebar" data-docsmith-toc><p class="toc-title">On this page</p><nav class="toc-links">' . implode('', $links) . '</nav></aside>';
+    }
+
+    /** @param list<array{slug: string, label: string, default: bool}> $versions */
+    private function versionSwitcherHtml(array $versions, string $currentSlug): string
+    {
+        if (count($versions) < 2) {
+            return '';
+        }
+
+        $options = array_map(
+            function (array $version) use ($currentSlug): string {
+                $selected = $version['slug'] === $currentSlug;
+                $label = htmlspecialchars($version['label'], ENT_QUOTES, 'UTF-8');
+                $slug = htmlspecialchars($version['slug'], ENT_QUOTES, 'UTF-8');
+
+                return sprintf(
+                    '<a class="version-link%s" href="%s/">%s</a>',
+                    $selected ? ' version-link-current' : '',
+                    $slug,
+                    $label,
+                );
+            },
+            $versions,
+        );
+
+        return '<nav class="version-switcher" data-docsmith-version-switcher aria-label="Version">' . implode('', $options) . '</nav>';
     }
 }

--- a/src/Render/SiteBuilder.php
+++ b/src/Render/SiteBuilder.php
@@ -107,9 +107,9 @@ final readonly class SiteBuilder
         $this->assets->publish($config->outputPath, $config->metadata);
         $hasRootIndex = $this->hasRootIndex($documents);
 
-        $versionSwitcher = $this->versionSwitcherHtml($versions, $currentSlug);
-
         foreach ($documents as $document) {
+            $versionSwitcher = $this->versionSwitcherHtml($versions, $currentSlug, $document, $config->baseUrl);
+
             $absoluteOutputPath = rtrim($config->outputPath, '/') . '/' . $document->outputPath;
             $directory = dirname($absoluteOutputPath);
 
@@ -137,7 +137,14 @@ final readonly class SiteBuilder
         }
 
         if (! $hasRootIndex) {
-            $landing = $this->landingPage($config, $documents, $versionSwitcher);
+            $rootDoc = new Document(
+                sourcePath: '',
+                relativePath: '',
+                outputPath: 'index.html',
+                title: $config->metadata->title,
+                markdown: '',
+            );
+            $landing = $this->landingPage($config, $documents, $this->versionSwitcherHtml($versions, $currentSlug, $rootDoc, $config->baseUrl));
             file_put_contents(rtrim($config->outputPath, '/') . '/index.html', $landing);
 
             if ($isDefault) {
@@ -796,22 +803,28 @@ HTML;
     }
 
     /** @param list<array{slug: string, label: string, default: bool}> $versions */
-    private function versionSwitcherHtml(array $versions, string $currentSlug): string
+    private function versionSwitcherHtml(array $versions, string $currentSlug, Document $document, string $baseUrl = '/'): string
     {
         if (count($versions) < 2) {
             return '';
         }
 
+        $pagePath = $document->url();
+        $pagePath = ltrim($pagePath, '/');
+
+        $basePath = rtrim($baseUrl, '/');
+
         $options = array_map(
-            function (array $version) use ($currentSlug): string {
+            function (array $version) use ($currentSlug, $pagePath, $basePath): string {
                 $selected = $version['slug'] === $currentSlug;
                 $label = htmlspecialchars($version['label'], ENT_QUOTES, 'UTF-8');
                 $slug = htmlspecialchars($version['slug'], ENT_QUOTES, 'UTF-8');
+                $href = $basePath . '/' . $slug . '/' . $pagePath;
 
                 return sprintf(
-                    '<a class="version-link%s" href="%s/">%s</a>',
+                    '<a class="version-link%s" href="%s">%s</a>',
                     $selected ? ' version-link-current' : '',
-                    $slug,
+                    $href,
                     $label,
                 );
             },

--- a/src/Render/SiteBuilder.php
+++ b/src/Render/SiteBuilder.php
@@ -100,17 +100,19 @@ final readonly class SiteBuilder
             throw new RuntimeException('The source directory does not contain any markdown files.');
         }
 
-        if (! is_dir($config->outputPath)) {
-            mkdir($config->outputPath, 0777, true);
+        $writeTarget = $isDefault ? $rootOutput : $config->outputPath;
+
+        if (! is_dir($writeTarget)) {
+            mkdir($writeTarget, 0777, true);
         }
 
-        $this->assets->publish($config->outputPath, $config->metadata);
+        $this->assets->publish($writeTarget, $config->metadata);
         $hasRootIndex = $this->hasRootIndex($documents);
 
         foreach ($documents as $document) {
             $versionSwitcher = $this->versionSwitcherHtml($versions, $currentSlug, $document, $config->baseUrl);
 
-            $absoluteOutputPath = rtrim($config->outputPath, '/') . '/' . $document->outputPath;
+            $absoluteOutputPath = rtrim($writeTarget, '/') . '/' . $document->outputPath;
             $directory = dirname($absoluteOutputPath);
 
             if (! is_dir($directory)) {
@@ -121,19 +123,6 @@ final readonly class SiteBuilder
                 $absoluteOutputPath,
                 $this->page($config, $document, $documents, $versionSwitcher),
             );
-
-            if ($isDefault) {
-                $rootPath = rtrim($rootOutput, '/') . '/' . $document->outputPath;
-                $rootDir = dirname($rootPath);
-                if (! is_dir($rootDir)) {
-                    mkdir($rootDir, 0777, true);
-                }
-
-                file_put_contents(
-                    $rootPath,
-                    $this->page($config, $document, $documents, $versionSwitcher),
-                );
-            }
         }
 
         if (! $hasRootIndex) {
@@ -145,21 +134,17 @@ final readonly class SiteBuilder
                 markdown: '',
             );
             $landing = $this->landingPage($config, $documents, $this->versionSwitcherHtml($versions, $currentSlug, $rootDoc, $config->baseUrl));
-            file_put_contents(rtrim($config->outputPath, '/') . '/index.html', $landing);
-
-            if ($isDefault) {
-                file_put_contents(rtrim($rootOutput, '/') . '/index.html', $landing);
-            }
+            file_put_contents(rtrim($writeTarget, '/') . '/index.html', $landing);
         }
 
-        $this->writeSearchIndex($config, $documents, ! $hasRootIndex);
+        $this->writeSearchIndex($config, $documents, ! $hasRootIndex, $writeTarget);
 
         if ($config->metadata->generateSitemap) {
-            $this->writeSitemap($config, $documents, ! $hasRootIndex);
+            $this->writeSitemap($config, $documents, ! $hasRootIndex, $writeTarget);
         }
 
         if ($config->metadata->generateNoJekyll) {
-            $this->writeNoJekyll($config);
+            $this->writeNoJekyll($config, $writeTarget);
         }
     }
 
@@ -570,18 +555,20 @@ HTML;
         return '<nav class="breadcrumbs" aria-label="Breadcrumbs">' . implode('<span class="breadcrumb-sep">/</span>', $parts) . '</nav>';
     }
 
-    private function writeNoJekyll(BuildConfig $config): void
+    private function writeNoJekyll(BuildConfig $config, ?string $outputPath = null): void
     {
-        file_put_contents(rtrim($config->outputPath, '/') . '/.nojekyll', '');
+        $target = $outputPath ?? $config->outputPath;
+        file_put_contents(rtrim($target, '/') . '/.nojekyll', '');
     }
 
     /** @param list<Document> $documents */
-    private function writeSitemap(BuildConfig $config, array $documents, bool $includeGeneratedRoot): void
+    private function writeSitemap(BuildConfig $config, array $documents, bool $includeGeneratedRoot, ?string $outputPath = null): void
     {
         if ($config->metadata->siteUrl === '') {
             return;
         }
 
+        $target = $outputPath ?? $config->outputPath;
         $entries = [];
 
         if ($includeGeneratedRoot) {
@@ -611,11 +598,11 @@ HTML;
 
         $xml .= "</urlset>\n";
 
-        file_put_contents(rtrim($config->outputPath, '/') . '/sitemap.xml', $xml);
+        file_put_contents(rtrim($target, '/') . '/sitemap.xml', $xml);
     }
 
     /** @param list<Document> $documents */
-    private function writeSearchIndex(BuildConfig $config, array $documents, bool $includeGeneratedRoot): void
+    private function writeSearchIndex(BuildConfig $config, array $documents, bool $includeGeneratedRoot, ?string $outputPath = null): void
     {
         $entries = array_map(
             function (Document $document): array {
@@ -642,8 +629,9 @@ HTML;
             ]);
         }
 
+        $target = $outputPath ?? $config->outputPath;
         file_put_contents(
-            rtrim($config->outputPath, '/') . '/search-index.json',
+            rtrim($target, '/') . '/search-index.json',
             json_encode($entries, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '[]'
         );
     }
@@ -809,8 +797,8 @@ HTML;
             return '';
         }
 
-        $pagePath = $document->url();
-        $pagePath = ltrim($pagePath, '/');
+        $pagePath = str_replace(['/index.html', 'index.html'], '/', $document->outputPath);
+        $pagePath = $pagePath === '/' ? '' : $pagePath;
 
         $basePath = rtrim($baseUrl, '/');
 
@@ -819,7 +807,9 @@ HTML;
                 $selected = $version['slug'] === $currentSlug;
                 $label = htmlspecialchars($version['label'], ENT_QUOTES, 'UTF-8');
                 $slug = htmlspecialchars($version['slug'], ENT_QUOTES, 'UTF-8');
-                $href = $basePath . '/' . $slug . '/' . $pagePath;
+                $href = $version['default']
+                    ? $basePath . '/' . $pagePath
+                    : $basePath . '/' . $slug . '/' . $pagePath;
 
                 return sprintf(
                     '<a class="version-link%s" href="%s">%s</a>',

--- a/tests/Feature/BuildSiteTest.php
+++ b/tests/Feature/BuildSiteTest.php
@@ -457,25 +457,30 @@ it('builds multiple versions with version switcher', function (): void {
         ->description('Docs with versions.')
         ->build();
 
-    // Both versions are built
+    // Non-default version built to its slug directory
     expect($outputPath . '/v1/index.html')->toBeFile()
         ->and($outputPath . '/v1/usage/index.html')->toBeFile()
-        ->and($outputPath . '/v2/index.html')->toBeFile()
-        ->and($outputPath . '/v2/usage/index.html')->toBeFile()
         ->and($outputPath . '/assets/app.css')->toBeFile();
 
-    // Default version (v2) is mirrored at root
-    expect($outputPath . '/index.html')->toBeFile();
+    // Default version at root (no duplication)
+    expect($outputPath . '/index.html')->toBeFile()
+        ->and($outputPath . '/usage/index.html')->toBeFile();
 
     // Default version (v2) content is at root
     $rootPage = file_get_contents($outputPath . '/index.html');
     expect($rootPage)->toContain('V2 Home');
 
-    // Version switcher is present
-    $v2Usage = file_get_contents($outputPath . '/v2/usage/index.html');
-    expect($v2Usage)
+    // Version switcher present on all pages
+    $rootUsage = file_get_contents($outputPath . '/usage/index.html');
+    expect($rootUsage)
         ->toContain('version-switcher')
         ->toContain('1.x')
         ->toContain('2.x')
         ->toContain('version-link-current');
+
+    // Default version links point to root (no slug prefix)
+    expect($rootUsage)->toContain('href="/usage/"');
+
+    // Non-default version links are slug-prefixed
+    expect($rootUsage)->toContain('href="/v1/usage/"');
 });

--- a/tests/Feature/BuildSiteTest.php
+++ b/tests/Feature/BuildSiteTest.php
@@ -434,3 +434,48 @@ MD);
     // Hidden page is excluded from pagination
     expect($visiblePage)->not->toContain('Next');
 });
+
+it('builds multiple versions with version switcher', function (): void {
+    $projectPath = sys_get_temp_dir() . '/docsmith-versions-' . uniqid();
+    $outputPath = sys_get_temp_dir() . '/docsmith-versions-dist-' . uniqid();
+
+    mkdir($projectPath . '/v1', 0777, true);
+    mkdir($projectPath . '/v2', 0777, true);
+
+    file_put_contents($projectPath . '/v1/index.md', "# V1 Home\n\nVersion 1 docs.\n");
+    file_put_contents($projectPath . '/v1/usage.md', "# V1 Usage\n\nUsing version 1.\n");
+    file_put_contents($projectPath . '/v2/index.md', "# V2 Home\n\nVersion 2 docs.\n");
+    file_put_contents($projectPath . '/v2/usage.md', "# V2 Usage\n\nUsing version 2.\n");
+
+    Docsmith::make()
+        ->versions([
+            'v1' => ['label' => '1.x', 'source' => $projectPath . '/v1'],
+            'v2' => ['label' => '2.x', 'source' => $projectPath . '/v2', 'default' => true],
+        ])
+        ->output($outputPath)
+        ->title('Versioned Docs')
+        ->description('Docs with versions.')
+        ->build();
+
+    // Both versions are built
+    expect($outputPath . '/v1/index.html')->toBeFile()
+        ->and($outputPath . '/v1/usage/index.html')->toBeFile()
+        ->and($outputPath . '/v2/index.html')->toBeFile()
+        ->and($outputPath . '/v2/usage/index.html')->toBeFile()
+        ->and($outputPath . '/assets/app.css')->toBeFile();
+
+    // Default version (v2) is mirrored at root
+    expect($outputPath . '/index.html')->toBeFile();
+
+    // Default version (v2) content is at root
+    $rootPage = file_get_contents($outputPath . '/index.html');
+    expect($rootPage)->toContain('V2 Home');
+
+    // Version switcher is present
+    $v2Usage = file_get_contents($outputPath . '/v2/usage/index.html');
+    expect($v2Usage)
+        ->toContain('version-switcher')
+        ->toContain('1.x')
+        ->toContain('2.x')
+        ->toContain('version-link-current');
+});


### PR DESCRIPTION
Introduces a versioned docs system allowing multiple doc versions (e.g., v1, v2) with a version switcher in the sidebar.

- VersionConfig: value object for version metadata (slug, label, source, default)
- Builder: add versions() fluent API, multi-version build loop
- SiteBuilder: buildVersion() renders each version into {output}/{slug}/, mirrors default version to root, injects version switcher in sidebar
- AssetPublisher: CSS for the version switcher pill-style buttons
- Tests: verify multi-version output, root mirroring, switcher markup