### PR TITLE
Load .env next to the sources manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 - **Private remote sources** — sync from private Git repositories by adding `'token' => '${ENV_VAR}'` (and optionally `'username'`) to a `docsmith.sources.php` entry. Tokens resolve from the environment at sync time; without an explicit token, `DOCSMITH_TOKEN` is used for any host and `GITHUB_TOKEN` / `GH_TOKEN` only for github.com hosts (never sent to third-party hosts). Requires [mrpunyapal/git-reader](https://github.com/MrPunyapal/git-reader) 0.2.0.
+- **.env support** — a `.env` file next to `docsmith.sources.php` is loaded Laravel-style (immutable); real environment variables always win.
 
 ## 0.3.0-beta.1 — 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 > Changes in **0.1.4 and after** — every release from `0.1.4` through `0.2.1`.
 > (`chore: regenerate docs` and merge commits are omitted.)
 
-## Unreleased
+## 0.3.0 � 2026-08-22
 
 ### Features
 - **Private remote sources** — sync from private Git repositories by adding `'token' => '${ENV_VAR}'` (and optionally `'username'`) to a `docsmith.sources.php` entry. Tokens resolve from the environment at sync time; without an explicit token, `DOCSMITH_TOKEN` is used for any host and `GITHUB_TOKEN` / `GH_TOKEN` only for github.com hosts (never sent to third-party hosts). Requires [mrpunyapal/git-reader](https://github.com/MrPunyapal/git-reader) 0.2.0.

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php": "^8.3",
         "league/commonmark": "^2.7",
         "mrpunyapal/git-reader": "^0.2",
-        "phiki/phiki": "^2.2"
+        "phiki/phiki": "^2.2",
+        "vlucas/phpdotenv": "^5.6"
     },
     "require-dev": {
         "laravel/pao": "^1.1",

--- a/md/remote-sources.md
+++ b/md/remote-sources.md
@@ -95,6 +95,7 @@ return [
 
 - **`'token' => '${ENV_VAR_NAME}'`** is the recommended form: DocSmith reads the variable from the environment at sync time and fails with a clear message if it is unset. A literal token string also works, but hardcoding secrets in a committed file is discouraged.
 - **Automatic fallbacks** — if no `token` key is present, DocSmith uses `DOCSMITH_TOKEN` for any HTTPS host, and `GITHUB_TOKEN` / `GH_TOKEN` only for repositories on github.com. GitHub tokens are never sent to third-party hosts, and fallback tokens are never attached to plain-HTTP URLs.
+- **`.env` files** — tokens may also live in a `.env` file next to `docsmith.sources.php`; real environment variables always take precedence.
 - **Never commit tokens.** Keep them in your shell profile or `.env`, and let CI inject them via repository secrets.
 
 

--- a/resources/boost/skills/docsmith-development/SKILL.md
+++ b/resources/boost/skills/docsmith-development/SKILL.md
@@ -73,7 +73,7 @@ php bin/docsmith build --sync      # or sync+build in one step
 
 Commit `docsmith.sources.lock.json` so repeat syncs are incremental; delete it to force a full refresh. Sync failures exit non-zero (CI-safe).
 
-Private repositories: add `'token' => '${ACME_PAT}'` (resolved from the environment; a missing variable is a config error naming it) and optional `'username'`. Without a token key, fallbacks apply: `DOCSMITH_TOKEN` works for any host; `GITHUB_TOKEN` / `GH_TOKEN` are used only for github.com hosts and never sent elsewhere. Never commit real tokens.
+Private repositories: add `'token' => '${ACME_PAT}'` (resolved from the environment; a missing variable is a config error naming it) and optional `'username'`. Without a token key, fallbacks apply: `DOCSMITH_TOKEN` works for any host; `GITHUB_TOKEN` / `GH_TOKEN` are used only for github.com hosts and never sent elsewhere. Tokens may also live in a `.env` file next to `docsmith.sources.php`; real environment variables always take precedence. Never commit real tokens.
 
 ## Open Graph images
 

--- a/src/RemoteSources/RemoteSources.php
+++ b/src/RemoteSources/RemoteSources.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Docsmith\RemoteSources;
 
+use Dotenv\Dotenv;
+
 /**
  * Convenience entry point for syncing remote sources.
  *
@@ -31,6 +33,8 @@ final class RemoteSources
         if (is_string($sources)) {
             $manifest = SourcesManifest::load($sources);
             $projectDir = dirname(realpath($sources) ?: $sources);
+
+            self::loadDotEnv($projectDir);
         } else {
             $manifest = [];
 
@@ -50,5 +54,24 @@ final class RemoteSources
                     ? $projectDir . '/' . SourceLock::FILE_NAME
                     : null,
             );
+    }
+
+    /**
+     * Loads a `.env` file sitting next to the sources manifest, Laravel-style.
+     *
+     * The immutable repository guarantees real environment variables always
+     * win over `.env` values; `safeLoad()` is a silent no-op when the file is
+     * missing.
+     */
+    private static function loadDotEnv(string $projectDir): void
+    {
+        if (! is_file($projectDir . '/.env')) {
+            return;
+        }
+
+        // "Unsafe" only means values are also registered via putenv(), which
+        // is what makes them visible to getenv() and thus to
+        // SourceCredentials; immutability still protects existing variables.
+        Dotenv::createUnsafeImmutable($projectDir)->safeLoad();
     }
 }

--- a/tests/Unit/RemoteSources/DotenvLoadingTest.php
+++ b/tests/Unit/RemoteSources/DotenvLoadingTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use Docsmith\RemoteSources\RemoteSources;
+use Docsmith\RemoteSources\SourceCredentials;
+use Docsmith\RemoteSources\SourcesManifest;
+use Docsmith\RemoteSources\SyncReport;
+
+/**
+ * @param  list<array<string, mixed>>  $sources
+ */
+function writeDotenvManifest(string $directory, array $sources): string
+{
+    if (! is_dir($directory)) {
+        mkdir($directory, 0777, true);
+    }
+
+    $path = $directory . '/docsmith.sources.php';
+    file_put_contents($path, '<?php return ' . var_export($sources, true) . ';');
+
+    return $path;
+}
+
+function writeEnvFile(string $directory, string $contents): void
+{
+    if (! is_dir($directory)) {
+        mkdir($directory, 0777, true);
+    }
+
+    file_put_contents($directory . '/.env', $contents);
+}
+
+/**
+ * Runs a sync that is expected to fail offline; the stream layer inside
+ * git-reader emits PHP warnings for unreachable hosts, which Pest would
+ * otherwise surface as warnings.
+ */
+/**
+ * @param  string|list<array<string, mixed>>  $sources
+ */
+function quietSync(string|array $sources): SyncReport
+{
+    set_error_handler(static fn (): bool => true);
+
+    try {
+        return RemoteSources::sync($sources);
+    } finally {
+        restore_error_handler();
+    }
+}
+
+/**
+ * A source that never leaves the machine: credentials are resolved before any
+ * network activity, and 127.0.0.1:1 refuses connections instantly.
+ *
+ * @return array<string, mixed>
+ */
+function offlineSource(): array
+{
+    return [
+        'repository' => 'https://127.0.0.1:1/acme/docs.git',
+        'ref' => 'main',
+        'target' => 'acme',
+        'token' => '${ACME_PAT}',
+    ];
+}
+
+/**
+ * @var string|false $acmePatBackup Saved ACME_PAT value; false means unset.
+ */
+$acmePatBackup = false;
+
+beforeEach(function () use (&$acmePatBackup): void {
+    SourceCredentials::$envReader = null;
+
+    $acmePatBackup = getenv('ACME_PAT');
+});
+
+afterEach(function () use (&$acmePatBackup): void {
+    SourceCredentials::$envReader = null;
+
+    if ($acmePatBackup === false) {
+        putenv('ACME_PAT');
+        unset($_ENV['ACME_PAT'], $_SERVER['ACME_PAT']);
+
+        return;
+    }
+
+    putenv('ACME_PAT=' . $acmePatBackup);
+});
+
+it('loads a .env file next to the manifest and feeds credential resolution', function (): void {
+    $directory = sys_get_temp_dir() . '/ds-env-' . uniqid();
+    $manifestPath = writeDotenvManifest($directory, [offlineSource()]);
+    writeEnvFile($directory, 'ACME_PAT=dotenv-token-123');
+
+    $report = quietSync($manifestPath);
+
+    expect(getenv('ACME_PAT'))->toBe('dotenv-token-123')
+        ->and($report->failures())->toBe(1);
+
+    $source = SourcesManifest::load($manifestPath)[0];
+
+    expect(SourceCredentials::resolve($source)?->token)->toBe('dotenv-token-123');
+});
+
+it('prefers a pre-existing environment variable over the .env value', function (): void {
+    putenv('ACME_PAT=real-env-token');
+
+    $directory = sys_get_temp_dir() . '/ds-env-' . uniqid();
+    $manifestPath = writeDotenvManifest($directory, [offlineSource()]);
+    writeEnvFile($directory, 'ACME_PAT=dotenv-token-123');
+
+    quietSync($manifestPath);
+
+    expect(getenv('ACME_PAT'))->toBe('real-env-token');
+});
+
+it('is a silent no-op when no .env file exists next to the manifest', function (): void {
+    $directory = sys_get_temp_dir() . '/ds-env-' . uniqid();
+    $manifestPath = writeDotenvManifest($directory, [offlineSource()]);
+
+    $report = quietSync($manifestPath);
+
+    expect(getenv('ACME_PAT'))->toBeFalse()
+        ->and($report->failures())->toBe(1)
+        ->and($report->entries()[0]['message'])
+        ->toContain('references the environment variable [ACME_PAT], which is not set');
+});
+
+it('skips the loader entirely for inline source definitions', function (): void {
+    // A `.env` sits right next to the working directory, yet inline arrays
+    // have no manifest file, so it must stay unloaded.
+    $directory = sys_get_temp_dir() . '/ds-env-' . uniqid();
+    writeEnvFile($directory, 'ACME_PAT=dotenv-token-123');
+
+    $previousDirectory = getcwd();
+    chdir($directory);
+
+    try {
+        $report = quietSync([offlineSource()]);
+    } finally {
+        if (is_string($previousDirectory)) {
+            chdir($previousDirectory);
+        }
+    }
+
+    expect(getenv('ACME_PAT'))->toBeFalse()
+        ->and($report->failures())->toBe(1)
+        ->and($report->entries()[0]['message'])
+        ->toContain('references the environment variable [ACME_PAT], which is not set');
+});


### PR DESCRIPTION
Adds Laravel-style .env loading for remote source credentials.

A .env file next to docsmith.sources.php is loaded before credential resolution, so tokens can live there instead of shell exports. Uses vlucas/phpdotenv with createUnsafeImmutable: values are registered via putenv so ${VAR} references in the manifest resolve, while real environment variables always keep precedence.

- Loader runs only when sources are given as a manifest file path; inline arrays skip it.
- Missing .env is a silent no-op.
- Four hermetic tests cover resolution through the loader, env precedence, missing file, and inline-array skip.
- Docs updated (remote-sources page, Boost skill) and CHANGELOG entry added. Changelog Unreleased section is retitled to 0.3.0 in preparation for tagging.

Requires the newly released mrpunyapal/git-reader 0.2.0.