### PR TITLE
feat: support custom CommonMark configuration

### DIFF
--- a/bin/docsmith
+++ b/bin/docsmith
@@ -8,6 +8,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use Docsmith\Docsmith;
 use Docsmith\RemoteSources\RemoteSources;
 use Docsmith\RemoteSources\InvalidSourcesConfiguration;
+use League\CommonMark\Extension\ExtensionInterface;
 
 const USAGE = <<<TXT
 Usage:
@@ -23,6 +24,8 @@ Build options:
   --accent-color=HEX    Accent color (default: #ff2d20)
   --accent-color-dark=HEX  Dark-mode accent color
   --custom-css=FILE     Path to custom CSS file
+  --commonmark-config=FILE
+                        PHP file returning CommonMark extensions and config
   --base-url=URL        Base URL (default: /)
   --right-sidebar       Enable the right sidebar
   --repository-url=URL  Repository URL for edit links
@@ -123,6 +126,21 @@ $builder = Docsmith::make()
     ->editBranch(stringOption($options, 'edit-branch', 'main'))
     ->editPrefix(stringOption($options, 'edit-prefix', ''))
     ->showDocsmithBadge(! boolOption($options, 'no-docsmith-badge'));
+
+$commonMarkConfigPath = stringOption($options, 'commonmark-config', '');
+
+if ($commonMarkConfigPath !== '') {
+    try {
+        $commonMark = loadCommonMarkConfig($commonMarkConfigPath);
+        $builder
+            ->commonMarkExtensions($commonMark['extensions'])
+            ->commonMarkConfig($commonMark['config']);
+    } catch (Throwable $error) {
+        fwrite(STDERR, '[Docsmith] Invalid CommonMark config: ' . $error->getMessage() . "\n");
+
+        exit(1);
+    }
+}
 
 $favicon = stringOption($options, 'favicon', '');
 
@@ -233,4 +251,48 @@ function boolOption(array $options, string $key): bool
     $value = $options[$key] ?? false;
 
     return $value === true || $value === '1' || $value === 'true';
+}
+
+/**
+ * @return array{extensions: list<ExtensionInterface>, config: array<string, mixed>}
+ */
+function loadCommonMarkConfig(string $path): array
+{
+    if (! is_file($path)) {
+        throw new InvalidArgumentException("File does not exist: {$path}");
+    }
+
+    $manifest = require $path;
+
+    if (! is_array($manifest)) {
+        throw new InvalidArgumentException('The file must return an array.');
+    }
+
+    $extensions = $manifest['extensions'] ?? [];
+    $config = $manifest['config'] ?? [];
+
+    if (! is_array($extensions) || ! array_is_list($extensions)) {
+        throw new InvalidArgumentException('[extensions] must be a list of CommonMark extensions.');
+    }
+
+    foreach ($extensions as $extension) {
+        if (! $extension instanceof ExtensionInterface) {
+            throw new InvalidArgumentException('[extensions] must contain only ExtensionInterface instances.');
+        }
+    }
+
+    if (! is_array($config)) {
+        throw new InvalidArgumentException('[config] must be an array.');
+    }
+
+    foreach (array_keys($config) as $key) {
+        if (! is_string($key)) {
+            throw new InvalidArgumentException('[config] must use string keys.');
+        }
+    }
+
+    return [
+        'extensions' => $extensions,
+        'config' => $config,
+    ];
 }

--- a/md/usage.md
+++ b/md/usage.md
@@ -33,6 +33,53 @@ Docsmith::make()
     ->build();
 ```
 
+## CommonMark extensions
+
+Docsmith enables CommonMark core and GitHub-flavored Markdown by default. Register additional League CommonMark extensions with the fluent API:
+
+```php
+use Docsmith\Docsmith;
+use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
+
+Docsmith::make()
+    ->source(__DIR__ . '/md')
+    ->output(__DIR__ . '/dist')
+    ->commonMarkExtensions([
+        new DescriptionListExtension(),
+    ])
+    ->commonMarkConfig([
+        'html_input' => 'strip',
+    ])
+    ->build();
+```
+
+Configuration passed to `commonMarkConfig()` overrides Docsmith's environment defaults and may include configuration for registered extensions. The static `Docsmith::build()` API also accepts `commonMarkExtensions` and `commonMarkConfig` arrays.
+
+For command-line builds, put both values in a PHP configuration file:
+
+```php
+<?php
+
+use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
+
+return [
+    'extensions' => [
+        new DescriptionListExtension(),
+    ],
+    'config' => [
+        'html_input' => 'strip',
+    ],
+];
+```
+
+Pass that file to the build command:
+
+```bash
+vendor/bin/docsmith build \
+    --source=md \
+    --commonmark-config=docsmith.commonmark.php
+```
+
 ## Command line
 
 Docsmith ships a standalone binary that builds a site without writing any PHP. After installing the package, run:
@@ -56,6 +103,7 @@ php bin/docsmith build --source=md --output=docs --title="Project Docs"
 | `--accent-color=HEX` | Accent color | `#ff2d20` |
 | `--accent-color-dark=HEX` | Dark-mode accent color | derived from accent |
 | `--custom-css=FILE` | Path to a custom CSS file | none |
+| `--commonmark-config=FILE` | PHP file returning CommonMark extensions and environment config | none |
 | `--base-url=URL` | Base URL | `/` |
 | `--right-sidebar` | Enable the right sidebar table of contents | off |
 | `--repository-url=URL` | Repository URL for edit links | none |

--- a/src/Builder/Builder.php
+++ b/src/Builder/Builder.php
@@ -12,6 +12,7 @@ use Docsmith\Content\Document;
 use Docsmith\Markdown\CommonMarkRenderer;
 use Docsmith\Render\OgImageGenerator;
 use Docsmith\Render\SiteBuilder;
+use League\CommonMark\Extension\ExtensionInterface;
 use LogicException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -66,6 +67,12 @@ final class Builder
     private bool $showDocsmithBadge = true;
 
     private bool $publishMedia = true;
+
+    /** @var list<ExtensionInterface> */
+    private array $commonMarkExtensions = [];
+
+    /** @var array<string, mixed> */
+    private array $commonMarkConfig = [];
 
     /** @var list<string> */
     private array $navigationOrder = [];
@@ -429,6 +436,33 @@ final class Builder
         return $this;
     }
 
+    /**
+     * Register additional League CommonMark extensions for Markdown rendering.
+     *
+     * @param list<ExtensionInterface> $extensions
+     */
+    public function commonMarkExtensions(array $extensions): self
+    {
+        $this->commonMarkExtensions = $extensions;
+
+        return $this;
+    }
+
+    /**
+     * Configure the League CommonMark environment.
+     *
+     * Values override Docsmith's defaults and may include extension-specific
+     * configuration.
+     *
+     * @param array<string, mixed> $config
+     */
+    public function commonMarkConfig(array $config): self
+    {
+        $this->commonMarkConfig = $config;
+
+        return $this;
+    }
+
     /** @param list<string> $order */
     public function navigationOrder(array $order): self
     {
@@ -691,7 +725,7 @@ final class Builder
         if ($this->readmeIndexPath !== null) {
             $readmePath = $this->resolveReadmePath();
             $sourcePath = dirname($readmePath);
-            $documents = (new ReadmeIndexImporter(new CommonMarkRenderer()))->import($readmePath, $this->readmeSkipSections);
+            $documents = (new ReadmeIndexImporter($this->commonMarkRenderer()))->import($readmePath, $this->readmeSkipSections);
         }
 
         $config = BuildConfig::fromInput(
@@ -720,7 +754,7 @@ final class Builder
             ogImage: $this->ogImage,
         );
 
-        (new SiteBuilder())->build($config, $documents);
+        (new SiteBuilder(renderer: $this->commonMarkRenderer()))->build($config, $documents);
 
         $this->generateOgImages($config, $documents);
     }
@@ -747,10 +781,15 @@ final class Builder
         );
     }
 
+    private function commonMarkRenderer(): CommonMarkRenderer
+    {
+        return new CommonMarkRenderer($this->commonMarkExtensions, $this->commonMarkConfig);
+    }
+
     private function buildDocs(): void
     {
         $outputPath = $this->requireOutputPath();
-        $siteBuilder = new SiteBuilder();
+        $siteBuilder = new SiteBuilder(renderer: $this->commonMarkRenderer());
         $dropdownGroups = [];
         $pageSets = [];
         $units = [];

--- a/src/Docsmith.php
+++ b/src/Docsmith.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Docsmith;
 
 use Docsmith\Builder\Builder;
+use League\CommonMark\Extension\ExtensionInterface;
 
 final class Docsmith
 {
+    /**
+     * @param list<ExtensionInterface> $commonMarkExtensions
+     * @param array<string, mixed> $commonMarkConfig
+     */
     public static function build(
         string $source,
         string $output = 'docs',
@@ -23,6 +28,8 @@ final class Docsmith
         string $editBranch = 'main',
         string $editPrefix = '',
         bool $showDocsmithBadge = true,
+        array $commonMarkExtensions = [],
+        array $commonMarkConfig = [],
     ): void {
         self::make()
             ->source($source)
@@ -39,6 +46,8 @@ final class Docsmith
             ->editBranch($editBranch)
             ->editPrefix($editPrefix)
             ->showDocsmithBadge($showDocsmithBadge)
+            ->commonMarkExtensions($commonMarkExtensions)
+            ->commonMarkConfig($commonMarkConfig)
             ->build();
     }
 

--- a/src/Markdown/CommonMarkRenderer.php
+++ b/src/Markdown/CommonMarkRenderer.php
@@ -6,6 +6,7 @@ namespace Docsmith\Markdown;
 
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\ExtensionInterface;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\MarkdownConverter;
 use Phiki\Grammar\Grammar;
@@ -19,15 +20,23 @@ final readonly class CommonMarkRenderer
 
     private Phiki $highlighter;
 
-    public function __construct()
+    /**
+     * @param iterable<ExtensionInterface> $extensions
+     * @param array<string, mixed> $config
+     */
+    public function __construct(iterable $extensions = [], array $config = [])
     {
-        $environment = new Environment([
+        $environment = new Environment($config + [
             'html_input' => 'allow',
             'allow_unsafe_links' => false,
         ]);
 
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
+        foreach ($extensions as $extension) {
+            $environment->addExtension($extension);
+        }
 
         $this->converter = new MarkdownConverter($environment);
         $this->highlighter = new Phiki();

--- a/tests/Feature/BuildSiteTest.php
+++ b/tests/Feature/BuildSiteTest.php
@@ -3,6 +3,43 @@
 declare(strict_types=1);
 
 use Docsmith\Docsmith;
+use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
+
+it('uses additional commonmark extensions in site builds', function (): void {
+    $sourcePath = sys_get_temp_dir() . '/docsmith-commonmark-' . uniqid();
+    $outputPath = sys_get_temp_dir() . '/docsmith-commonmark-out-' . uniqid();
+    mkdir($sourcePath, 0777, true);
+    file_put_contents($sourcePath . '/index.md', "# Glossary\n\nTerm\n: Definition\n");
+
+    Docsmith::build(
+        source: $sourcePath,
+        output: $outputPath,
+        commonMarkExtensions: [new DescriptionListExtension()],
+    );
+
+    expect((string) file_get_contents($outputPath . '/index.html'))
+        ->toContain('<dl>')
+        ->toContain('<dt>Term</dt>')
+        ->toContain('<dd>Definition</dd>');
+});
+
+it('uses additional commonmark environment config in site builds', function (): void {
+    $sourcePath = sys_get_temp_dir() . '/docsmith-commonmark-config-' . uniqid();
+    $outputPath = sys_get_temp_dir() . '/docsmith-commonmark-config-out-' . uniqid();
+    mkdir($sourcePath, 0777, true);
+    file_put_contents($sourcePath . '/index.md', "# Config\n\n<div>\nremoved\n</div>\n");
+
+    Docsmith::make()
+        ->source($sourcePath)
+        ->output($outputPath)
+        ->commonMarkConfig(['html_input' => 'strip'])
+        ->build();
+
+    $html = (string) file_get_contents($outputPath . '/index.html');
+
+    expect(str_contains($html, '<div>'))->toBeFalse()
+        ->and(str_contains($html, 'removed'))->toBeFalse();
+});
 
 it('rewrites markdown links between pages into built page urls', function (): void {
     $sourcePath = sys_get_temp_dir() . '/docsmith-md-links-' . uniqid();

--- a/tests/Feature/CommonMarkCliTest.php
+++ b/tests/Feature/CommonMarkCliTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+it('uses commonmark extensions and environment config in cli builds', function (): void {
+    $projectPath = sys_get_temp_dir() . '/docsmith-commonmark-cli-' . uniqid();
+    $sourcePath = $projectPath . '/md';
+    $outputPath = $projectPath . '/docs';
+    mkdir($sourcePath, 0777, true);
+
+    file_put_contents($sourcePath . '/index.md', <<<'MD'
+        # Glossary
+
+        Term
+        : Definition
+
+        <div>
+        removed
+        </div>
+        MD);
+
+    $commonMarkConfigPath = $projectPath . '/commonmark.php';
+    file_put_contents($commonMarkConfigPath, <<<'PHP'
+        <?php
+
+        use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
+
+        return [
+            'extensions' => [new DescriptionListExtension()],
+            'config' => ['html_input' => 'strip'],
+        ];
+        PHP);
+
+    $command = [
+        PHP_BINARY,
+        dirname(__DIR__, 2) . '/bin/docsmith',
+        'build',
+        '--source=' . $sourcePath,
+        '--output=' . $outputPath,
+        '--commonmark-config=' . $commonMarkConfigPath,
+    ];
+    $pipes = [];
+    $process = proc_open($command, [
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ], $pipes);
+
+    if (! is_resource($process)) {
+        throw new RuntimeException('Unable to start the Docsmith CLI process.');
+    }
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $exitCode = proc_close($process);
+
+    expect($exitCode)->toBe(0, $stderr)
+        ->and($stdout)->toContain('Built docs');
+
+    $html = (string) file_get_contents($outputPath . '/index.html');
+
+    expect($html)->toContain('<dl>')
+        ->toContain('<dt>Term</dt>')
+        ->toContain('<dd>Definition</dd>')
+        ->and(str_contains($html, '<div>'))->toBeFalse()
+        ->and(str_contains($html, 'removed'))->toBeFalse();
+});

--- a/tests/Unit/CommonMarkRendererTest.php
+++ b/tests/Unit/CommonMarkRendererTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Docsmith\Markdown\CommonMarkRenderer;
+use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
+
+it('registers additional commonmark extensions', function (): void {
+    $renderer = new CommonMarkRenderer([
+        new DescriptionListExtension(),
+    ]);
+
+    expect($renderer->render("Term\n: Definition"))
+        ->toContain('<dl>')
+        ->toContain('<dt>Term</dt>')
+        ->toContain('<dd>Definition</dd>');
+});
+
+it('passes additional configuration to the commonmark environment', function (): void {
+    $renderer = new CommonMarkRenderer(config: [
+        'html_input' => 'strip',
+    ]);
+
+    $html = $renderer->render("Before\n\n<div>\nremoved\n</div>\n\nAfter");
+
+    expect(str_contains($html, '<div>'))->toBeFalse()
+        ->and(str_contains($html, 'removed'))->toBeFalse()
+        ->and($html)
+        ->toContain('Before')
+        ->toContain('After');
+});


### PR DESCRIPTION
## Summary

Adds support for customizing Docsmith’s League CommonMark environment from both the PHP API and CLI.

## Changes

- Add `commonMarkExtensions()` to register additional CommonMark extensions.
- Add `commonMarkConfig()` for environment and extension-specific configuration.
- Support both options through the fluent and static PHP APIs.
- Apply custom rendering consistently across standard, README-index, hub, and versioned builds.
- Add --commonmark-config=FILE for CLI builds.
- Validate CLI configuration files and provide clear error messages.
- Document PHP and CLI usage.

## Fluent API example

```php
use Docsmith\Docsmith;
use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;

Docsmith::make()
    ->source(__DIR__ . '/md')
    ->output(__DIR__ . '/docs')
    ->commonMarkExtensions([
        new DescriptionListExtension(),
    ])
    ->commonMarkConfig([
        'html_input' => 'strip',
    ])
    ->build();
```

## CLI example

Create docsmith.commonmark.php:

```php
use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;

return [
    'extensions' => [
        new DescriptionListExtension(),
    ],
    'config' => [
        'html_input' => 'strip',
    ],
];
```

Then pass it to the CLI:

```bash
vendor/bin/docsmith build \
    --source=md \
    --output=docs \
    --commonmark-config=docsmith.commonmark.php
```

## Testing

- Added direct renderer coverage.
- Added PHP API integration coverage.
- Added an end-to-end CLI test covering extensions and environment configuration.
- Full suite passes with 100 tests and 364 assertions.
- PHPStan, Rector, Pint, and diff checks pass.