### PR TITLE
feat: render github-style alerts in markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 > Changes in **0.1.4 and after** — every release from `0.1.4` through `0.2.1`.
 > (`chore: regenerate docs` and merge commits are omitted.)
 
+## Unreleased
+
+### Features
+- **GitHub-style alerts**: block quotes starting with `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, or `[!CAUTION]` (case-insensitive, marker alone on the first line) render as colored callout boxes with icons in both light and dark themes. Implemented as a built-in League CommonMark extension that is always enabled; unknown markers and regular block quotes are unaffected. Callouts use GitHub-compatible class names (`.markdown-alert markdown-alert-{type}`) so custom CSS written for GitHub also works with Docsmith.
+
 ## 0.3.2 - 2026-08-24
 
 ### Features

--- a/md/development.md
+++ b/md/development.md
@@ -9,6 +9,9 @@ composer test:unit     # pest --parallel
 composer test          # all of the above
 ```
 
+> [!NOTE]
+> Rector and Pint run in check-only mode during CI — apply fixes locally with `composer lint` before pushing.
+
 ## Tooling
 
 The repository is configured with:

--- a/md/index.md
+++ b/md/index.md
@@ -43,6 +43,9 @@ Docsmith::build(
 
 This reads Markdown from `md/` and writes the site to `docs/` by default, which works directly with GitHub Pages.
 
+> [!TIP]
+> Docsmith ships [Agent Skills](installation.md#install-the-ai-agent-skills) that teach coding agents how to build and write docs with it — install them once and let your agent do the wiring.
+
 ## Documentation
 
 - [Installation](installation.md)

--- a/md/open-graph.md
+++ b/md/open-graph.md
@@ -112,9 +112,15 @@ Capture runs during `build()` when a generated mode is enabled. It is incrementa
 
 To force a full regeneration without the method, delete `og/.capturist-cache.json`.
 
+> [!TIP]
+> Use `captureOg(false)` while writing locally for fast rebuilds, then let CI run the full capture with screenshots.
+
 If capture is enabled but Node, capturist, or Chromium is missing, the build fails with install instructions.
 
 ## CI
+
+> [!WARNING]
+> CI runners ship without Chromium and Playwright browsers. Install them before the build step or every capture-enabled build will fail.
 
 Install Node dependencies and Chromium before a docs build that runs capture:
 

--- a/md/remote-sources.md
+++ b/md/remote-sources.md
@@ -78,6 +78,9 @@ Syncing is restricted by default:
 
 ## Private repositories
 
+> [!CAUTION]
+> Never commit tokens to your repository. Keep them in your shell profile or `.env`, and let CI inject them via repository secrets.
+
 Pass a token in `docsmith.sources.php`:
 
 ```php
@@ -96,7 +99,6 @@ return [
 - **`'token' => '${ENV_VAR_NAME}'`** is the recommended form. Docsmith reads the variable from the environment at sync time and fails with a clear message naming the variable if it is unset. A literal token string also works, but hardcoding secrets in a committed file is discouraged.
 - **Automatic fallbacks.** If no `token` key is present, Docsmith uses `DOCSMITH_TOKEN` for any HTTPS host, and `GITHUB_TOKEN` / `GH_TOKEN` only for repositories on github.com. GitHub tokens are never sent to third-party hosts, and fallback tokens are never attached to plain-HTTP URLs.
 - **`.env` files.** Tokens may also live in a `.env` file next to `docsmith.sources.php`. Real environment variables always take precedence.
-- **Never commit tokens.** Keep them in your shell profile or `.env`, and let CI inject them via repository secrets.
 
 ## Programmatic use
 

--- a/md/usage.md
+++ b/md/usage.md
@@ -80,6 +80,20 @@ vendor/bin/docsmith build \
     --commonmark-config=docsmith.commonmark.php
 ```
 
+## Alerts
+
+GitHub-style alerts are enabled by default. Start a block quote with `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, or `[!CAUTION]` (case-insensitive) to turn it into a colored callout:
+
+```md
+> [!TIP]
+> Helpful advice for doing things better.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention.
+```
+
+The marker must be alone on its first line, and content follows on the lines below. Alerts support any Markdown inside — lists, code blocks, links. Unknown markers like `[!FOO]` and regular block quotes are rendered as plain block quotes. Styling ships with the built-in theme; override `.markdown-alert` in custom CSS to change it.
+
 ## Command line
 
 Docsmith ships a standalone binary that builds a site without writing any PHP. After installing the package, run:

--- a/md/usage.md
+++ b/md/usage.md
@@ -94,6 +94,23 @@ GitHub-style alerts are enabled by default. Start a block quote with `[!NOTE]`, 
 
 The marker must be alone on its first line, and content follows on the lines below. Alerts support any Markdown inside — lists, code blocks, links. Unknown markers like `[!FOO]` and regular block quotes are rendered as plain block quotes. Styling ships with the built-in theme; override `.markdown-alert` in custom CSS to change it.
 
+Every type in action — this is what the five markers look like in the built theme:
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better.
+
+> [!IMPORTANT]
+> Key information users need to know.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
 ## Command line
 
 Docsmith ships a standalone binary that builds a site without writing any PHP. After installing the package, run:

--- a/src/Assets/AssetPublisher.php
+++ b/src/Assets/AssetPublisher.php
@@ -1012,6 +1012,102 @@ pre.phiki .line::before {
     padding: 0.15rem 0.4rem;
 }
 
+.markdown-alert {
+    --alert-accent: var(--accent);
+    --alert-tint: var(--accent-soft);
+    margin: 1.15rem 0 1.35rem;
+    padding: 0.8rem 1rem 0.9rem;
+    border-left: 0.22rem solid var(--alert-accent);
+    border-radius: 0.5rem;
+    background: var(--alert-tint);
+}
+
+.markdown-alert > :last-child {
+    margin-bottom: 0;
+}
+
+.markdown-alert-title {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin: 0 0 0.4rem;
+    color: var(--alert-accent);
+    font-family: "Space Grotesk", "Segoe UI", sans-serif;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.markdown-alert-title::before {
+    content: '';
+    flex-shrink: 0;
+    width: 1.05rem;
+    height: 1.05rem;
+    background-color: currentColor;
+    -webkit-mask-image: var(--alert-icon);
+    mask-image: var(--alert-icon);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+}
+
+.markdown-alert-note {
+    --alert-accent: #0969da;
+    --alert-tint: rgba(9, 105, 218, 0.08);
+    --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M12 16v-4'/%3E%3Cpath d='M12 8h.01'/%3E%3C/svg%3E");
+}
+
+.markdown-alert-tip {
+    --alert-accent: #1a7f37;
+    --alert-tint: rgba(26, 127, 55, 0.08);
+    --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1.3.5 2.6 1.5 3.5.7.7 1.3 1.5 1.5 2.5'/%3E%3Cpath d='M9 18h6'/%3E%3Cpath d='M10 22h4'/%3E%3C/svg%3E");
+}
+
+.markdown-alert-important {
+    --alert-accent: #8250df;
+    --alert-tint: rgba(130, 80, 223, 0.08);
+    --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9'/%3E%3Cpath d='M13.73 21a2 2 0 0 1-3.46 0'/%3E%3C/svg%3E");
+}
+
+.markdown-alert-warning {
+    --alert-accent: #9a6700;
+    --alert-tint: rgba(154, 103, 0, 0.1);
+    --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m21.73 18-8-14a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 20h16a2 2 0 0 0 1.73-2Z'/%3E%3Cpath d='M12 9v4'/%3E%3Cpath d='M12 17h.01'/%3E%3C/svg%3E");
+}
+
+.markdown-alert-caution {
+    --alert-accent: #cf222e;
+    --alert-tint: rgba(207, 34, 46, 0.08);
+    --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7.86 2h8.28L22 7.86v8.28L16.14 22H7.86L2 16.14V7.86z'/%3E%3Cpath d='m15 9-6 6'/%3E%3Cpath d='m9 9 6 6'/%3E%3C/svg%3E");
+}
+
+:root[data-docsmith-theme='dark'] .markdown-alert-note {
+    --alert-accent: #4493f8;
+    --alert-tint: rgba(68, 147, 248, 0.12);
+}
+
+:root[data-docsmith-theme='dark'] .markdown-alert-tip {
+    --alert-accent: #3fb950;
+    --alert-tint: rgba(63, 185, 80, 0.12);
+}
+
+:root[data-docsmith-theme='dark'] .markdown-alert-important {
+    --alert-accent: #ab7df8;
+    --alert-tint: rgba(171, 125, 248, 0.13);
+}
+
+:root[data-docsmith-theme='dark'] .markdown-alert-warning {
+    --alert-accent: #d29922;
+    --alert-tint: rgba(210, 153, 34, 0.12);
+}
+
+:root[data-docsmith-theme='dark'] .markdown-alert-caution {
+    --alert-accent: #f85149;
+    --alert-tint: rgba(248, 81, 73, 0.12);
+}
+
 .hero {
     width: 100%;
     max-width: none;

--- a/src/Markdown/CommonMarkRenderer.php
+++ b/src/Markdown/CommonMarkRenderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Docsmith\Markdown;
 
+use Docsmith\Markdown\GitHubAlerts\GitHubAlertsExtension;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\ExtensionInterface;
@@ -33,6 +34,7 @@ final readonly class CommonMarkRenderer
 
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
+        $environment->addExtension(new GitHubAlertsExtension());
 
         foreach ($extensions as $extension) {
             $environment->addExtension($extension);

--- a/src/Markdown/GitHubAlerts/AlertBlockQuoteRenderer.php
+++ b/src/Markdown/GitHubAlerts/AlertBlockQuoteRenderer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Docsmith\Markdown\GitHubAlerts;
+
+use InvalidArgumentException;
+use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
+use League\CommonMark\Extension\CommonMark\Renderer\Block\BlockQuoteRenderer;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
+use Stringable;
+
+/**
+ * Renders tagged block quotes as GitHub-style callout boxes. Untagged block
+ * quotes fall through to the core renderer untouched.
+ */
+final readonly class AlertBlockQuoteRenderer implements NodeRendererInterface
+{
+    /** @var array<string, string> */
+    private const array LABELS = [
+        'note' => 'Note',
+        'tip' => 'Tip',
+        'important' => 'Important',
+        'warning' => 'Warning',
+        'caution' => 'Caution',
+    ];
+
+    public function __construct(
+        private BlockQuoteRenderer $fallback = new BlockQuoteRenderer(),
+    ) {
+    }
+
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): Stringable
+    {
+        if (! $node instanceof BlockQuote) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected %s, got %s.',
+                BlockQuote::class,
+                get_debug_type($node),
+            ));
+        }
+
+        if (! $node->data->has('github-alert')) {
+            return $this->fallback->render($node, $childRenderer);
+        }
+
+        $type = $node->data->get('github-alert');
+        $label = is_string($type) ? self::LABELS[$type] ?? null : null;
+
+        if ($label === null) {
+            return $this->fallback->render($node, $childRenderer);
+        }
+
+        $separator = $childRenderer->getInnerSeparator();
+        $filling = $childRenderer->renderNodes($node->children());
+        $title = new HtmlElement('p', ['class' => 'markdown-alert-title'], $label);
+
+        return new HtmlElement('div', ['class' => 'markdown-alert markdown-alert-' . $type], match ($filling) {
+            '' => $separator,
+            default => $separator . $title . $separator . $filling . $separator,
+        });
+    }
+}

--- a/src/Markdown/GitHubAlerts/AlertsProcessor.php
+++ b/src/Markdown/GitHubAlerts/AlertsProcessor.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Docsmith\Markdown\GitHubAlerts;
+
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
+use League\CommonMark\Node\Block\Paragraph;
+use League\CommonMark\Node\Inline\Newline;
+use League\CommonMark\Node\Inline\Text;
+use League\CommonMark\Node\Node;
+
+/**
+ * Detects alert markers in block quotes and tags them with the alert type.
+ *
+ * The marker must be the only content of the first line, e.g. `[!NOTE]`,
+ * matching GitHub's behavior. Tagged block quotes are rendered as callouts by
+ * AlertBlockQuoteRenderer; everything else stays a regular block quote.
+ */
+final class AlertsProcessor
+{
+    private const string ALERT_PATTERN = '/^\[!(note|tip|important|warning|caution)\]\s*$/i';
+
+    public function __invoke(DocumentParsedEvent $event): void
+    {
+        foreach ($this->blockQuotes($event->getDocument()) as $blockQuote) {
+            $this->tagAlert($blockQuote);
+        }
+    }
+
+    /** @return list<BlockQuote> */
+    private function blockQuotes(Node $node): array
+    {
+        $quotes = [];
+
+        foreach ($node->children() as $child) {
+            if ($child instanceof BlockQuote) {
+                $quotes[] = $child;
+            }
+
+            $quotes = [...$quotes, ...$this->blockQuotes($child)];
+        }
+
+        return $quotes;
+    }
+
+    private function tagAlert(BlockQuote $blockQuote): void
+    {
+        $paragraph = $blockQuote->firstChild();
+
+        if (! $paragraph instanceof Paragraph) {
+            return;
+        }
+
+        $marker = $paragraph->firstChild();
+
+        if (
+            ! $marker instanceof Text
+            || preg_match(self::ALERT_PATTERN, $marker->getLiteral(), $matches) !== 1
+        ) {
+            return;
+        }
+
+        $blockQuote->data->set('github-alert', strtolower($matches[1]));
+
+        $marker->detach();
+
+        // Drop the line break that followed the marker so content starts clean.
+        if ($paragraph->firstChild() instanceof Newline) {
+            $paragraph->firstChild()->detach();
+        }
+
+        // The marker was the paragraph's only content.
+        if (!$paragraph->firstChild() instanceof Node) {
+            $paragraph->detach();
+        }
+    }
+}

--- a/src/Markdown/GitHubAlerts/GitHubAlertsExtension.php
+++ b/src/Markdown/GitHubAlerts/GitHubAlertsExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Docsmith\Markdown\GitHubAlerts;
+
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
+use League\CommonMark\Extension\ExtensionInterface;
+
+/**
+ * Adds support for GitHub-flavored alerts inside block quotes:
+ *
+ *     > [!NOTE]
+ *     > Useful information.
+ *
+ * Supported markers are [!NOTE], [!TIP], [!IMPORTANT], [!WARNING], and
+ * [!CAUTION]. Matching is case-insensitive and the marker must be alone on
+ * the first line of the block quote. Anything else renders as a regular
+ * block quote.
+ */
+final class GitHubAlertsExtension implements ExtensionInterface
+{
+    /**
+     * Must be higher than the core block quote renderer's default priority so
+     * alerts win while non-alert block quotes fall through to it.
+     */
+    private const int RENDERER_PRIORITY = 10;
+
+    public function register(EnvironmentBuilderInterface $environment): void
+    {
+        $environment->addEventListener(DocumentParsedEvent::class, new AlertsProcessor());
+        $environment->addRenderer(BlockQuote::class, new AlertBlockQuoteRenderer(), self::RENDERER_PRIORITY);
+    }
+}

--- a/tests/Feature/BuildSiteTest.php
+++ b/tests/Feature/BuildSiteTest.php
@@ -54,6 +54,22 @@ it('rejects commonmark config keys that are not strings', function (): void {
         ->toThrow(InvalidArgumentException::class, 'string keys');
 });
 
+it('renders github style alerts in built sites', function (): void {
+    $sourcePath = sys_get_temp_dir() . '/docsmith-alerts-' . uniqid();
+    $outputPath = sys_get_temp_dir() . '/docsmith-alerts-out-' . uniqid();
+    mkdir($sourcePath, 0777, true);
+    file_put_contents($sourcePath . '/index.md', "# Alerts\n\n> [!CAUTION]\n> Watch out.\n");
+
+    Docsmith::build(source: $sourcePath, output: $outputPath);
+
+    expect((string) file_get_contents($outputPath . '/index.html'))
+        ->toContain('<div class="markdown-alert markdown-alert-caution">')
+        ->toContain('<p class="markdown-alert-title">Caution</p>')
+        ->toContain('<p>Watch out.</p>')
+        ->and((string) file_get_contents($outputPath . '/assets/app.css'))
+        ->toContain('.markdown-alert');
+});
+
 it('rewrites markdown links between pages into built page urls', function (): void {
     $sourcePath = sys_get_temp_dir() . '/docsmith-md-links-' . uniqid();
     mkdir($sourcePath . '/guides', 0777, true);

--- a/tests/Unit/CommonMarkRendererTest.php
+++ b/tests/Unit/CommonMarkRendererTest.php
@@ -29,3 +29,80 @@ it('passes additional configuration to the commonmark environment', function ():
         ->toContain('Before')
         ->toContain('After');
 });
+
+it('renders github style alerts', function (): void {
+    $renderer = new CommonMarkRenderer();
+
+    $html = $renderer->render("> [!NOTE]\n> Useful information.");
+
+    expect(str_contains($html, '<blockquote>'))->toBeFalse()
+        ->and($html)
+        ->toContain('<div class="markdown-alert markdown-alert-note">')
+        ->toContain('<p class="markdown-alert-title">Note</p>')
+        ->toContain('<p>Useful information.</p>');
+});
+
+it('supports every github alert type', function (string $type, string $label): void {
+    $renderer = new CommonMarkRenderer();
+
+    expect($renderer->render("> [!{$type}]\n> Body"))
+        ->toContain('markdown-alert markdown-alert-' . strtolower($type))
+        ->toContain('<p class="markdown-alert-title">' . $label . '</p>');
+})->with([
+    ['note', 'Note'],
+    ['tip', 'Tip'],
+    ['important', 'Important'],
+    ['warning', 'Warning'],
+    ['caution', 'Caution'],
+]);
+
+it('matches alert markers case insensitively', function (): void {
+    $renderer = new CommonMarkRenderer();
+
+    expect($renderer->render("> [!Caution]\n> Risky."))
+        ->toContain('<div class="markdown-alert markdown-alert-caution">')
+        ->toContain('<p class="markdown-alert-title">Caution</p>');
+});
+
+it('keeps multiline content inside alerts', function (): void {
+    $renderer = new CommonMarkRenderer();
+
+    $html = $renderer->render("> [!WARNING]\n> First paragraph.\n>\n> - one\n> - two");
+
+    expect($html)
+        ->toContain('markdown-alert-warning')
+        ->toContain('<p>First paragraph.</p>')
+        ->toContain('<li>one</li>')
+        ->toContain('<li>two</li>');
+});
+
+it('leaves unknown alert markers as regular block quotes', function (): void {
+    $renderer = new CommonMarkRenderer();
+
+    $html = $renderer->render("> [!FOO]\n> stays plain.");
+
+    expect(str_contains($html, 'markdown-alert'))->toBeFalse()
+        ->and($html)
+        ->toContain('<blockquote>')
+        ->toContain('[!FOO]');
+});
+
+it('requires alert markers to be alone on their line', function (): void {
+    $renderer = new CommonMarkRenderer();
+
+    $html = $renderer->render('> [!NOTE] inline text');
+
+    expect(str_contains($html, 'markdown-alert'))->toBeFalse()
+        ->and($html)->toContain('<blockquote>');
+});
+
+it('leaves regular block quotes untouched', function (): void {
+    $renderer = new CommonMarkRenderer();
+
+    $html = $renderer->render('> Just a quote.');
+
+    expect(str_contains($html, 'markdown-alert'))->toBeFalse()
+        ->and($html)
+        ->toContain('<blockquote>')
+        ->toContain('<p>Just a quote.</p>');
+});


### PR DESCRIPTION
## Summary

Adds support for GitHub-flavored alerts (`> [!TIP]`, `> [!NOTE]`, etc.) rendered as styled callout boxes. Enabled by default — no configuration needed.

## Changes

- Add a built-in League CommonMark extension under `Docsmith\Markdown\GitHubAlerts`:
  - `AlertsProcessor` walks the parsed document and tags block quotes whose first line is exactly `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, or `[!CAUTION]` (case-insensitive).
  - `AlertBlockQuoteRenderer` renders tagged quotes as callouts and delegates everything else to the core block quote renderer, so plain block quotes are byte-for-byte unchanged.
  - `GitHubAlertsExtension` wires both into the environment (renderer registered above core priority).
- Registered by default in `CommonMarkRenderer` alongside GFM, so all build paths get it: standard, README-index, hub, versioned.
- Output uses GitHub-compatible class names (`markdown-alert markdown-alert-{type}`) so custom CSS written for GitHub also works with Docsmith builds.
- Ship default styling in the generated `app.css`: accent border + tinted background per type, uppercase title with icon (inline SVG masks, same pattern as existing icons), light and dark theme palettes via CSS variables.

### Behavior notes

- Marker must be alone on its first line (matches GitHub); `> [!NOTE] inline text` stays a plain block quote.
- Unknown markers like `[!FOO]` render as regular block quotes.
- Alerts accept any Markdown content inside (lists, code blocks, links).

## Example

```md
> [!WARNING]
> Urgent info that needs immediate user attention.
```

renders as:

```html
<div class="markdown-alert markdown-alert-warning">
    <p class="markdown-alert-title">Warning</p>
    <p>Urgent info that needs immediate user attention.</p>
</div>
```

## Testing

- Unit tests for the renderer: all five types + labels, case-insensitivity, multiline/nested content, unknown markers, marker-not-alone, untouched regular block quotes.
- Feature test covering a full site build (callout HTML present, `.markdown-alert` styles published to `assets/app.css`).
- Full suite passes with 117 tests and 407 assertions.
- Rector, Pint, and PHPStan (level max) pass.
