### PR TITLE
fix: resolve autoloader when docsmith is installed as a dependency

### DIFF
--- a/bin/docsmith
+++ b/bin/docsmith
@@ -3,7 +3,23 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+$autoloader = null;
+
+foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php'] as $file) {
+    if (is_file($file)) {
+        $autoloader = $file;
+
+        break;
+    }
+}
+
+if ($autoloader === null) {
+    fwrite(STDERR, "[Docsmith] Unable to find the Composer autoloader. Run `composer install` first.\n");
+
+    exit(1);
+}
+
+require $autoloader;
 
 use Docsmith\Docsmith;
 use Docsmith\RemoteSources\RemoteSources;

--- a/tests/Feature/CommonMarkCliTest.php
+++ b/tests/Feature/CommonMarkCliTest.php
@@ -118,9 +118,13 @@ it('fails clearly when the commonmark config has invalid extensions', function (
 });
 
 it('runs when docsmith is installed as a dependency', function (): void {
-    $projectPath = sys_get_temp_dir() . '/docsmith-dependency-' . uniqid();
+    $projectPath = sys_get_temp_dir() . '/docsmith-dependency-' . bin2hex(random_bytes(8));
+
+    if (! mkdir($projectPath . '/vendor/mrpunyapal/docsmith/bin', 0700, true)) {
+        throw new RuntimeException('Unable to create the temporary project directory.');
+    }
+
     $packageBinPath = $projectPath . '/vendor/mrpunyapal/docsmith/bin';
-    mkdir($packageBinPath, 0777, true);
 
     copy(dirname(__DIR__, 2) . '/bin/docsmith', $packageBinPath . '/docsmith');
 

--- a/tests/Feature/CommonMarkCliTest.php
+++ b/tests/Feature/CommonMarkCliTest.php
@@ -117,6 +117,34 @@ it('fails clearly when the commonmark config has invalid extensions', function (
         ->and($result['stderr'])->toContain('must implement');
 });
 
+it('runs when docsmith is installed as a dependency', function (): void {
+    $projectPath = sys_get_temp_dir() . '/docsmith-dependency-' . uniqid();
+    $packageBinPath = $projectPath . '/vendor/mrpunyapal/docsmith/bin';
+    mkdir($packageBinPath, 0777, true);
+
+    copy(dirname(__DIR__, 2) . '/bin/docsmith', $packageBinPath . '/docsmith');
+
+    // Simulate the consuming project's autoloader three levels up from the binary.
+    file_put_contents(
+        $projectPath . '/vendor/autoload.php',
+        '<?php require ' . var_export(dirname(__DIR__, 2) . '/vendor/autoload.php', true) . ';',
+    );
+
+    $sourcePath = $projectPath . '/md';
+    mkdir($sourcePath, 0777, true);
+    file_put_contents($sourcePath . '/index.md', '# Dependency build');
+
+    $result = docsmithCliProcess([
+        'build',
+        '--source=' . $sourcePath,
+        '--output=' . $projectPath . '/docs',
+    ]);
+
+    expect($result['exitCode'])->toBe(0, $result['stderr'])
+        ->and($result['stdout'])->toContain('Built docs')
+        ->and(file_exists($projectPath . '/docs/index.html'))->toBeTrue();
+});
+
 /**
  * Run the Docsmith binary in a subprocess and capture its output.
  *


### PR DESCRIPTION
## Summary

Fixes #13.

`bin/docsmith` required `__DIR__ . '/../vendor/autoload.php'`, which only resolves when Docsmith is the root project. When installed as a dependency (`composer require mrpunyapal/docsmith`), Composer places the binary at `vendor/mrpunyapal/docsmith/bin/docsmith` and there is no nested `vendor/` inside the package, so every `docsmith` command died with:

```
Fatal error: Uncaught Error: Failed opening required '.../vendor/mrpunyapal/docsmith/bin/../vendor/autoload.php'
```

## Changes

- Try both standard locations: package-local autoloader first (repo development), then `__DIR__ . '/../../../autoload.php'` for dependency installs (the pattern suggested in the issue).
- If neither exists, exit with a clear message pointing at `composer install` instead of a raw fatal error.
- Regression test that reproduces the exact dependency layout: a fake consuming project with `vendor/mrpunyapal/docsmith/bin/docsmith` plus a stub project autoloader, running a real build through it. Verified to fail against the old binary and pass with the fix.

## Testing

- New end-to-end test: `runs when docsmith is installed as a dependency`.
- Full suite passes with 118 tests and 410 assertions; Rector, Pint, and PHPStan (level max) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI installation detection across multiple Composer autoloader locations.
  - Added a clear error message and failure status when no autoloader is found.
  - The CLI now correctly loads the consuming project’s autoloader when installed as a dependency.
  - Verified successful documentation builds in project-level installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->